### PR TITLE
Add user context

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -17,3 +17,5 @@ export const AGARTEX_SERVICE_USERS_URL = AGARTEX_SERVICE_BASE_URL + '/users';
 
 /* This matches the @blue2 in variables.module.less. */
 export const BLUE_2 = '#7F98B8';
+
+export const USER_STORAGE_KEY = 'agartex-user';

--- a/src/context/UserContextProvider.tsx
+++ b/src/context/UserContextProvider.tsx
@@ -1,6 +1,8 @@
-import { ReactNode, createContext } from 'react';
+import { ReactNode, createContext, useEffect } from 'react';
 import { User, UserContextType } from '@model';
+import { USER_STORAGE_KEY } from '@constants';
 import { useLocalStorage } from 'util/local-storage/useLocalStorage';
+import { useNavigate } from 'react-router-dom';
 
 interface Props {
   children: ReactNode | ReactNode[]
@@ -8,14 +10,20 @@ interface Props {
 
 export const UserContext = createContext<UserContextType | null>(null);
 
-const USER_STORAGE_KEY = 'agartex-user';
-
 const UserProvider = (props: Props) => {
+  const navigate = useNavigate();
+
   const { 
     storedValue: user, 
     setValue: setUser, 
     clearValue: logout
   } = useLocalStorage<User>(USER_STORAGE_KEY);
+
+  useEffect(() => {
+    if (!user) {
+      navigate('/login');
+    }
+  }, [user]);
 
   return (
     <UserContext.Provider

--- a/src/context/UserContextProvider.tsx
+++ b/src/context/UserContextProvider.tsx
@@ -1,0 +1,29 @@
+import { ReactNode, createContext } from 'react';
+import { User, UserContextType } from '@model';
+import { useLocalStorage } from 'util/local-storage/useLocalStorage';
+
+interface Props {
+  children: ReactNode | ReactNode[]
+}
+
+export const UserContext = createContext<UserContextType | null>(null);
+
+const USER_STORAGE_KEY = 'agartex-user';
+
+const UserProvider = (props: Props) => {
+  const { 
+    storedValue: user, 
+    setValue: setUser, 
+    clearValue: logout
+  } = useLocalStorage<User>(USER_STORAGE_KEY);
+
+  return (
+    <UserContext.Provider
+      value={{ user, setUser, logout }}
+    >
+      { props.children }
+    </UserContext.Provider>
+  );
+};
+
+export default UserProvider;

--- a/src/context/__test__/UserContextProvider.test.tsx
+++ b/src/context/__test__/UserContextProvider.test.tsx
@@ -1,0 +1,75 @@
+import { render, waitFor } from '@testing-library/react';
+import { UserContext } from 'context/UserContextProvider';
+import { useContext } from 'react';
+
+const mockStoredValue = {
+  userId: 'mock_userId',
+  email: 'mock_email'
+};
+const mockSetValue = jest.fn();
+const mockClearValue = jest.fn();
+
+jest.mock('util/local-storage/useLocalStorage', () => ({
+  ...jest.requireActual('util/local-storage/useLocalStorage'),
+  useLocalStorage: jest.fn().mockImplementation(() => ({
+    storedValue: mockStoredValue, 
+    setValue: mockSetValue,
+    clearValue: mockClearValue
+  }))
+}));
+
+import UserProvider from 'context/UserContextProvider';
+
+const UserConsumer = () => {
+  const { user, setUser, logout } = useContext(UserContext);
+
+  return (
+    <>
+      <p>{user?.userId}</p>
+      <p>{user?.email}</p>
+      <button 
+        data-testid='change-user-button'
+        onClick={() => setUser({
+          userId: 'newUserId',
+          email: 'newEmail'
+        })} />
+      <button
+        data-testid='logout-button'
+        onClick={logout} />
+    </>
+  );
+};
+
+const renderConsumerWithUserContext = () => {
+  return render(
+    <UserProvider>
+      <UserConsumer />
+    </UserProvider>
+  );
+};
+
+describe('<UserContextProvider/>', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should load initial user context from browser local storage', () => {
+    const { getByText } = renderConsumerWithUserContext();
+    getByText('mock_userId');
+    getByText('mock_email');
+  });
+
+  it('should set user and save it in local storage', () => {
+    const { getByTestId, queryByText} = renderConsumerWithUserContext();
+    getByTestId('change-user-button').click();
+    waitFor(() => expect(queryByText('newUserId')).not.toBeNull());
+    waitFor(() => expect(queryByText('newEmail')).not.toBeNull());
+  });
+
+  it('should clear local storage on logout', () => {
+    const { getByTestId, queryByText } = renderConsumerWithUserContext();
+    getByTestId('logout-button').click();
+    waitFor(() => expect(queryByText('mock_userId')).toBeNull());
+    waitFor(() => expect(queryByText('mock_email')).toBeNull());
+  });
+});

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,19 +1,22 @@
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import { CreateAccountPage, LoginPage, MainPage, ProjectsPage } from './pages';
 import App from './App';
+import UserProvider from 'context/UserContextProvider';
 import { createRoot } from 'react-dom/client';
 
 const container = document.getElementById('root');
 const root = createRoot(container);
 root.render(
   <BrowserRouter basename={'/'}>
-    <Routes>
-      <Route path='/login' element={<LoginPage />} />
-      <Route path='/create-account' element={<CreateAccountPage />} />
-      <Route path='/' element={<App />}>
-        <Route path='' element={<ProjectsPage />} />
-        <Route path='/:projectId' element={<MainPage />} />
-      </Route>
-    </Routes>
+    <UserProvider>
+      <Routes>
+        <Route path='/login' element={<LoginPage />} />
+        <Route path='/create-account' element={<CreateAccountPage />} />
+        <Route path='/' element={<App />}>
+          <Route path='' element={<ProjectsPage />} />
+          <Route path='/:projectId' element={<MainPage />} />
+        </Route>
+      </Routes>
+    </UserProvider>
   </BrowserRouter>
 );

--- a/src/model.ts
+++ b/src/model.ts
@@ -14,3 +14,14 @@ export interface Project {
   contributorsCount: number,
   owner: string
 }
+
+export interface User {
+  userId: string,
+  email: string
+}
+
+export interface UserContextType {
+  user: User,
+  setUser: (user: User) => void,
+  logout: () => void
+}

--- a/src/pages/login/__test__/LoginPage.test.tsx
+++ b/src/pages/login/__test__/LoginPage.test.tsx
@@ -16,10 +16,26 @@ jest.mock('react-router-dom', () => ({
 }));
 
 import LoginPage from '../LoginPage';
+import { UserContext } from 'context/UserContextProvider';
 
 const mockValues = {
   validEmail: 'valid@email.com',
   validPassword: '1Str0ng#P4ssw0rd@!',
+};
+
+
+const mockSetUser = jest.fn();
+
+const renderInMockContext = () => {
+  return render(
+    <UserContext.Provider value={{
+      user: null,
+      setUser: mockSetUser,
+      logout: jest.fn()
+    }}>
+      <LoginPage />
+    </UserContext.Provider>
+  );
 };
 
 describe('<LoginPage/>', () => {
@@ -28,7 +44,7 @@ describe('<LoginPage/>', () => {
   });
 
   it('should render with all children', () => {
-    const { getByTestId } = render(<LoginPage />);
+    const { getByTestId } = renderInMockContext();
     getByTestId('login-agartex-logo');
     getByTestId('login-email-text-input');
     getByTestId('login-password-text-input');
@@ -37,7 +53,7 @@ describe('<LoginPage/>', () => {
   });
 
   it('should render children with proper texts', () => {
-    const { getByText, getByTestId } = render(<LoginPage />);
+    const { getByText, getByTestId } = renderInMockContext();
     expect(getByTestId('login-email-text-input')
       .getAttribute('placeholder')).toEqual('Enter your email');
     expect(getByTestId('login-password-text-input')
@@ -48,7 +64,7 @@ describe('<LoginPage/>', () => {
   });
 
   it('should call login service on login button click', async () => {
-    const { getByTestId } = render(<LoginPage />);
+    const { getByTestId } = renderInMockContext();
 
     await act(async () => {
       const emailTextInput = getByTestId('login-email-text-input');
@@ -64,8 +80,25 @@ describe('<LoginPage/>', () => {
     });
   });
 
+  it('should save user context after successful login', async () => {
+    const { getByTestId } = renderInMockContext();
+
+    await act(async () => {
+      const emailTextInput = getByTestId('login-email-text-input');
+      await userEvent.type(emailTextInput, mockValues.validEmail);
+      const passwordTextInput = getByTestId('login-password-text-input');
+      await userEvent.type(passwordTextInput, mockValues.validPassword);
+      getByTestId('login-button').click();
+    });
+    
+    expect(mockSetUser).toHaveBeenCalledWith({
+      userId: 'mockUserId',
+      email: mockValues.validEmail
+    });
+  });
+
   it('should redirect to main page after successful login', async () => {
-    const { getByTestId } = render(<LoginPage />);
+    const { getByTestId } = renderInMockContext();
 
     await act(async () => {
       const emailTextInput = getByTestId('login-email-text-input');
@@ -79,7 +112,7 @@ describe('<LoginPage/>', () => {
   });
 
   it('should redirect to create account page on create account button click', () => {
-    const { getByTestId } = render(<LoginPage />);
+    const { getByTestId } = renderInMockContext();
     getByTestId('create-account-button').click();
     expect(mockNavigate).toHaveBeenCalledWith('/create-account');
   });
@@ -91,7 +124,7 @@ describe('<LoginPage/>', () => {
       });
     });
 
-    const { getByTestId, queryByTestId } = render(<LoginPage />);
+    const { getByTestId, queryByTestId } = renderInMockContext();
 
     await act(async () => {
       const emailTextInput = getByTestId('login-email-text-input');

--- a/src/pages/login/form/LoginForm.tsx
+++ b/src/pages/login/form/LoginForm.tsx
@@ -1,8 +1,9 @@
 import { Button, LoadingSpinner, TextInput } from '@components';
 import { EMAIL_VALIDATION_RULES, PASSWORD_VALIDATION_RULES } from '../../../util/validators/common-rules';
 import { Field, useForm } from '../../../util/forms/forms';
-import { Fragment } from 'react';
+import { Fragment, useContext } from 'react';
 import { OperationState } from '@model';
+import { UserContext } from 'context/UserContextProvider';
 import { login } from './../service/login-service';
 import styles from './LoginForm.module.less';
 import { validateString } from '../../../util/validators/string-validator';
@@ -25,6 +26,8 @@ const formDefinition: Map<string, Field> = new Map([
 ]);
 
 const LoginForm = (props: Props) => {
+  const { setUser } = useContext(UserContext);
+
   const { 
     formState, 
     isInErrorState, 
@@ -49,6 +52,10 @@ const LoginForm = (props: Props) => {
 
     login(buildRequestBody())
       .then(() => {
+        setUser({
+          userId: 'mockUserId', // TODO: well...
+          email: formState.get('email').value as string
+        });
         props.setFormState(OperationState.SUCCESS);
       })
       .catch((error) => {

--- a/src/pages/main/Main.tsx
+++ b/src/pages/main/Main.tsx
@@ -1,13 +1,15 @@
 import { AiFillFolder, AiFillTool } from 'react-icons/ai';
+import { useContext, useEffect, useState } from 'react';
 import { Button } from '@components';
 import Editor from './Editor';
+import { UserContext } from 'context/UserContextProvider';
 import { compileDocument } from './service/compilation-service';
 import styles from './Main.module.less';
 import { useNavigate } from 'react-router-dom';
-import { useState } from 'react';
-
 
 const MainPage = () => {
+  const { user, logout } = useContext(UserContext);
+
   const [documentSource, setDocumentSource] = useState<string>('');
   const [documentUrl, setDocumentUrl] = useState<string>('example.pdf');
   const [compilationError, setCompilationError] = useState<string | null>(null);
@@ -15,10 +17,16 @@ const MainPage = () => {
 
   const navigate = useNavigate();
 
-  const logout = () => {
-    localStorage.removeItem('user-token');
+  const onLogoutClick = () => {
+    logout();
     navigate('/login');
   };
+
+  useEffect(() => {
+    if (!user) {
+      navigate('/login');
+    }
+  }, [user]);
 
   const onCompilationButtonClick = () => {
     setCompilationError(null);
@@ -41,10 +49,10 @@ const MainPage = () => {
   return (
     <div className={styles.root}>
       <div className={styles.header}>
-        Username
+        { user && (user.userId + ' ' + user.email) }
         <Button
           ariaLabel='logout button'
-          onClick={logout}
+          onClick={onLogoutClick}
           testId='logout-button'
           value='Logout'/>
         <Button 

--- a/src/pages/main/Main.tsx
+++ b/src/pages/main/Main.tsx
@@ -1,11 +1,10 @@
 import { AiFillFolder, AiFillTool } from 'react-icons/ai';
-import { useContext, useEffect, useState } from 'react';
+import { useContext, useState } from 'react';
 import { Button } from '@components';
 import Editor from './Editor';
 import { UserContext } from 'context/UserContextProvider';
 import { compileDocument } from './service/compilation-service';
 import styles from './Main.module.less';
-import { useNavigate } from 'react-router-dom';
 
 const MainPage = () => {
   const { user, logout } = useContext(UserContext);
@@ -15,18 +14,9 @@ const MainPage = () => {
   const [compilationError, setCompilationError] = useState<string | null>(null);
   const [compilationLogs, setCompilationLogs] = useState<string>('');
 
-  const navigate = useNavigate();
-
   const onLogoutClick = () => {
     logout();
-    navigate('/login');
   };
-
-  useEffect(() => {
-    if (!user) {
-      navigate('/login');
-    }
-  }, [user]);
 
   const onCompilationButtonClick = () => {
     setCompilationError(null);
@@ -49,7 +39,7 @@ const MainPage = () => {
   return (
     <div className={styles.root}>
       <div className={styles.header}>
-        { user && (user.userId + ' ' + user.email) }
+        { user?.email }
         <Button
           ariaLabel='logout button'
           onClick={onLogoutClick}

--- a/src/pages/main/__test__/Main.test.tsx
+++ b/src/pages/main/__test__/Main.test.tsx
@@ -1,3 +1,4 @@
+import { UserContext } from 'context/UserContextProvider';
 import MainPage from '../Main';
 import { render } from '@testing-library/react';
 
@@ -8,22 +9,45 @@ jest.mock('react-router-dom', () => ({
 }));
 jest.mock('../Editor');
 
+const mockUser = {
+  userId: 'mockUserId',
+  email: 'mockEmail'
+};
+const mockLogout = jest.fn();
+
+const renderInMockContext = () => {
+  return render(
+    <UserContext.Provider value={{
+      user: mockUser,
+      setUser: jest.fn(),
+      logout: mockLogout
+    }}>
+      <MainPage />
+    </UserContext.Provider>
+  );
+};
+
 describe('<MainPage/>', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
   it('should render with all children', () => {
-    const { getByTestId } = render(<MainPage />);
+    const { getByTestId } = renderInMockContext();
     getByTestId('logout-button');
     getByTestId('toolbar');
     getByTestId('editor');
   });
 
-  it('should logout on logout button click', async () => {
-    const { getByTestId } = render(<MainPage />);
+  it('should clear user context on logout button click', () => {
+    const { getByTestId } = renderInMockContext();
     getByTestId('logout-button').click();
-    // TODO: test cookie removal
-    expect(mockNavigate).toHaveBeenCalled();
+    expect(mockLogout).toHaveBeenCalled();
+  });
+
+  it('should navigate to login page on logout button click', () => {
+    const { getByTestId } = renderInMockContext();
+    getByTestId('logout-button').click();
+    expect(mockNavigate).toHaveBeenCalledWith('/login');
   });
 });

--- a/src/pages/main/__test__/Main.test.tsx
+++ b/src/pages/main/__test__/Main.test.tsx
@@ -2,10 +2,9 @@ import { UserContext } from 'context/UserContextProvider';
 import MainPage from '../Main';
 import { render } from '@testing-library/react';
 
-const mockNavigate = jest.fn();
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
-  useNavigate: () => mockNavigate
+  useNavigate: () => jest.fn()
 }));
 jest.mock('../Editor');
 
@@ -39,15 +38,9 @@ describe('<MainPage/>', () => {
     getByTestId('editor');
   });
 
-  it('should clear user context on logout button click', () => {
+  it('should call logout callback from user context on logout button click', () => {
     const { getByTestId } = renderInMockContext();
     getByTestId('logout-button').click();
     expect(mockLogout).toHaveBeenCalled();
-  });
-
-  it('should navigate to login page on logout button click', () => {
-    const { getByTestId } = renderInMockContext();
-    getByTestId('logout-button').click();
-    expect(mockNavigate).toHaveBeenCalledWith('/login');
   });
 });

--- a/src/pages/projects/ProjectsPage.tsx
+++ b/src/pages/projects/ProjectsPage.tsx
@@ -6,7 +6,6 @@ import { ProjectsList } from './projects-list/ProjectsList';
 import { UserBox } from './user-box/UserBox';
 import { UserContext } from 'context/UserContextProvider';
 import styles from './ProjectsPage.module.less';
-import { useNavigate } from 'react-router-dom';
 
 const initProjects = [
   {
@@ -40,7 +39,6 @@ const ProjectsPage = () => {
 
   const [projects, setProjects] = useState<Project[]>(initProjects);
   const [createProjectModalState, setCreateProjectModalState] = useState<ModalState>(ModalState.CLOSED);
-  const navigate = useNavigate();
 
   const submitProjectCreation = (newProjectName: string) => {
     setProjects([...projects, {
@@ -55,7 +53,6 @@ const ProjectsPage = () => {
 
   const onLogoutClick = () => {
     logout();
-    navigate('/login');
   };
 
   return (

--- a/src/pages/projects/ProjectsPage.tsx
+++ b/src/pages/projects/ProjectsPage.tsx
@@ -1,11 +1,12 @@
 import { ModalState, Project } from '@model';
+import { useContext, useState } from 'react';
 import { Button } from '@components';
 import CreateProjectModal from './create-project-modal/CreateProjectModal';
 import { ProjectsList } from './projects-list/ProjectsList';
 import { UserBox } from './user-box/UserBox';
+import { UserContext } from 'context/UserContextProvider';
 import styles from './ProjectsPage.module.less';
 import { useNavigate } from 'react-router-dom';
-import { useState } from 'react';
 
 const initProjects = [
   {
@@ -35,6 +36,8 @@ const initProjects = [
 ];
 
 const ProjectsPage = () => {
+  const { logout } = useContext(UserContext);
+
   const [projects, setProjects] = useState<Project[]>(initProjects);
   const [createProjectModalState, setCreateProjectModalState] = useState<ModalState>(ModalState.CLOSED);
   const navigate = useNavigate();
@@ -50,7 +53,8 @@ const ProjectsPage = () => {
     }]);
   };
 
-  const logout = () => {
+  const onLogoutClick = () => {
+    logout();
     navigate('/login');
   };
 
@@ -67,7 +71,7 @@ const ProjectsPage = () => {
       <ProjectsList projects={projects} />
 
       <UserBox 
-        onLogoutButtonClick={logout}
+        onLogoutButtonClick={onLogoutClick}
       />
 
       <CreateProjectModal

--- a/src/pages/projects/__test__/ProjectsPage.test.tsx
+++ b/src/pages/projects/__test__/ProjectsPage.test.tsx
@@ -1,25 +1,65 @@
 import { render, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import ProjectsPage from '../ProjectsPage';
+import { UserContext } from 'context/UserContextProvider';
 
-const renderProjectsPage = () => {
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate
+}));
+
+const mockUser = {
+  userId: 'mockUserId',
+  email: 'mockEmail'
+};
+const mockLogout = jest.fn();
+
+const renderInMockContext = () => {
   return render(
-    <MemoryRouter>
-      <ProjectsPage />
-    </MemoryRouter>
+    <UserContext.Provider value={{
+      user: mockUser,
+      setUser: jest.fn(),
+      logout: mockLogout
+    }}>
+      <MemoryRouter>
+        <ProjectsPage />
+      </MemoryRouter>
+    </UserContext.Provider>
   );
 };
 
 describe('<ProjectsPage />', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('should render with all its children', () => {
-    const { getByTestId } = renderProjectsPage();
+    const { getByTestId } = renderInMockContext();
     getByTestId('create-new-project-button');
     getByTestId('projects-page-user-box');
   });
 
   it('should display create project modal on create project button click', async () => {
-    const { getByTestId, queryByTestId } = renderProjectsPage();
+    const { getByTestId, queryByTestId } = renderInMockContext();
     getByTestId('create-new-project-button').click();
     await waitFor(() => expect(queryByTestId('create-project-name-text-input')).not.toBe(null));
+  });
+
+  it('should display user email in user box', () => {
+    const { getByText } = renderInMockContext();
+    getByText('mockEmail');
+  });
+  
+  it('should clear user context on logout button click', () => {
+    const { getByTestId } = renderInMockContext();
+    getByTestId('user-box-logout-button').click();
+    expect(mockLogout).toHaveBeenCalled();
+  });
+
+  it('should navigate to login page on logout button click', () => {
+    const { getByTestId } = renderInMockContext();
+    getByTestId('user-box-logout-button').click();
+    expect(mockNavigate).toHaveBeenCalledWith('/login');
   });
 });

--- a/src/pages/projects/__test__/ProjectsPage.test.tsx
+++ b/src/pages/projects/__test__/ProjectsPage.test.tsx
@@ -3,10 +3,9 @@ import { MemoryRouter } from 'react-router-dom';
 import ProjectsPage from '../ProjectsPage';
 import { UserContext } from 'context/UserContextProvider';
 
-const mockNavigate = jest.fn();
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
-  useNavigate: () => mockNavigate
+  useNavigate: () => jest.fn()
 }));
 
 const mockUser = {
@@ -51,15 +50,9 @@ describe('<ProjectsPage />', () => {
     getByText('mockEmail');
   });
   
-  it('should clear user context on logout button click', () => {
+  it('should call logout callback from user context on logout button click', () => {
     const { getByTestId } = renderInMockContext();
     getByTestId('user-box-logout-button').click();
     expect(mockLogout).toHaveBeenCalled();
-  });
-
-  it('should navigate to login page on logout button click', () => {
-    const { getByTestId } = renderInMockContext();
-    getByTestId('user-box-logout-button').click();
-    expect(mockNavigate).toHaveBeenCalledWith('/login');
   });
 });

--- a/src/pages/projects/user-box/UserBox.tsx
+++ b/src/pages/projects/user-box/UserBox.tsx
@@ -1,9 +1,8 @@
-import { useContext, useEffect } from 'react';
 import { Button } from '@components';
 import { UserContext } from 'context/UserContextProvider';
 import pfp from './pfp.png';
 import styles from './UserBox.module.less';
-import { useNavigate } from 'react-router-dom';
+import { useContext } from 'react';
 
 interface Props {
   onLogoutButtonClick: () => void
@@ -11,13 +10,6 @@ interface Props {
 
 const UserBox = (props: Props) => {
   const { user } = useContext(UserContext);
-  const navigate = useNavigate();
-
-  useEffect(() => {
-    if (!user) {
-      navigate('/login');
-    }
-  }, [user]);
 
   return (
     <div 

--- a/src/pages/projects/user-box/UserBox.tsx
+++ b/src/pages/projects/user-box/UserBox.tsx
@@ -1,12 +1,24 @@
+import { useContext, useEffect } from 'react';
 import { Button } from '@components';
+import { UserContext } from 'context/UserContextProvider';
 import pfp from './pfp.png';
 import styles from './UserBox.module.less';
+import { useNavigate } from 'react-router-dom';
 
 interface Props {
   onLogoutButtonClick: () => void
 }
 
 const UserBox = (props: Props) => {
+  const { user } = useContext(UserContext);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!user) {
+      navigate('/login');
+    }
+  }, [user]);
+
   return (
     <div 
       data-testid='projects-page-user-box'
@@ -18,7 +30,7 @@ const UserBox = (props: Props) => {
       />
 
       <div className={styles.userDetailsContainer}>
-        <label>user_email@gmail.com</label>
+        <label>{ user && user.email }</label>
       </div>
 
       <Button

--- a/src/util/local-storage/useLocalStorage.ts
+++ b/src/util/local-storage/useLocalStorage.ts
@@ -1,0 +1,30 @@
+import { useState } from 'react';
+
+const getInitialValue = <T>(key: string): T | null => {
+  try {
+    const item = localStorage.getItem(key);
+    return item ? JSON.parse(item) : null;
+  } catch (error) {
+    console.log(error);
+    return null;
+  }
+};
+
+export const useLocalStorage = <T>(key: string) => {
+  const [storedValue, setStoredValue] = useState<T | null>(getInitialValue(key));
+
+  const setValue = (value: T) => {
+    try {
+      value ? 
+        localStorage.setItem(key, JSON.stringify(value)) :
+        localStorage.removeItem(key);
+      setStoredValue(value);
+    } catch (error) {
+      console.log(error);
+    }
+  };
+
+  const clearValue = () => setValue(null);
+  
+  return { storedValue, setValue, clearValue };
+};


### PR DESCRIPTION
- adds `User` and `UserContext` types
- adds `UserProvider` that exposes values `{user:User, setUser: (user:User)=>void, logout: ()=>void}`
- wraps whole app with `UserProvider`
- adds utility custom hook `useLocalStorage`
- saves user context in local storage and react context when logging in
- clears user context from local storage and react context when logging out
- navigates to `/login` page whenever UserContext is attempted to be used, but is null

resolves #29 